### PR TITLE
Create "theme extras" directory

### DIFF
--- a/rootdir/init.rc
+++ b/rootdir/init.rc
@@ -464,6 +464,7 @@ on post-fs-data
     mkdir /data/system 0775 system system
     mkdir /data/system/heapdump 0700 system system
     mkdir /data/system/users 0775 system system
+    mkdir /data/system/theme 0755 system system
 
     mkdir /data/system_de 0770 system system
     mkdir /data/system_ce 0770 system system


### PR DESCRIPTION
This creates /data/system/theme in init.rc. Historically, this
was done in ThemeService in CMTE. However, in a OMS/Subs
environment, OverlayManagerService is strictly dedicated to
handling overlays and nothing more.

Change-Id: I775e41310019695c4db82ccc9916dd14c8f690cd